### PR TITLE
fix: use Rent struct literal instead of with_lamports_per_byte

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -818,7 +818,11 @@ impl TestValidator {
     ) -> Self {
         let test_validator = TestValidatorGenesis::default()
             .fee_rate_governor(FeeRateGovernor::new(target_lamports_per_signature, 0))
-            .rent(Rent::with_lamports_per_byte(1))
+            .rent(Rent {
+                lamports_per_byte_year: 1,
+                exemption_threshold: 1.0,
+                ..Rent::default()
+            })
             .faucet_addr(faucet_addr)
             .start_with_mint_address(mint_address, socket_addr_space)
             .expect("validator start failed");
@@ -843,7 +847,11 @@ impl TestValidator {
     ) -> Self {
         TestValidatorGenesis::default()
             .fee_rate_governor(FeeRateGovernor::new(target_lamports_per_signature, 0))
-            .rent(Rent::with_lamports_per_byte(1))
+            .rent(Rent {
+                lamports_per_byte_year: 1,
+                exemption_threshold: 1.0,
+                ..Rent::default()
+            })
             .faucet_addr(faucet_addr)
             .start_async_with_mint_address(mint_keypair, socket_addr_space)
             .await


### PR DESCRIPTION
Upstream anza-xyz/agave v4.0.0-beta.5 pins solana-rent = "3.0.0", which doesn't have `Rent::with_lamports_per_byte()`. That method was only added in solana-rent 4.0.0+ and is used on upstream master (which pins 4.1.0).

The Firedancer patches branch commit [1a68228a63](https://github.com/firedancer-io/agave/commit/1a68228a63) had replaced the `Rent { lamports_per_byte_year: 1, exemption_threshold: 1.0, ..Rent::default() }` struct literals with `Rent::with_lamports_per_byte(1)`.

The next time we rebase onto a newer agave release that uses solana-rent >= 4.0.0, the `with_lamports_per_byte()` form will work again naturally.